### PR TITLE
Fix compile error on Apple Clang

### DIFF
--- a/fc_btree.h
+++ b/fc_btree.h
@@ -61,7 +61,7 @@ template <typename T, typename U> struct TreePairRef<BTreePair<T, U>> {
   using type = std::pair<const T &, U &>;
 };
 
-template <typename TreePair> using PairRefType = TreePairRef<TreePair>::type;
+template <typename TreePair> using PairRefType = typename TreePairRef<TreePair>::type;
 
 template <typename T, typename U>
 bool operator==(const BTreePair<T, U> &lhs,
@@ -304,12 +304,12 @@ requires(Fanout >= 2) class BTreeBase {
   };
 
   template <typename IterTraits> struct BTreeIterator {
-    using difference_type = IterTraits::difference_type;
-    using value_type = IterTraits::value_type;
-    using pointer = IterTraits::pointer;
-    using reference = IterTraits::reference;
-    using iterator_category = IterTraits::iterator_category;
-    using iterator_concept = IterTraits::iterator_concept;
+    using difference_type = typename IterTraits::difference_type;
+    using value_type = typename IterTraits::value_type;
+    using pointer = typename IterTraits::pointer;
+    using reference = typename IterTraits::reference;
+    using iterator_category = typename IterTraits::iterator_category;
+    using iterator_concept = typename IterTraits::iterator_concept;
 
     Node *node_ = nullptr;
     attr_t index_;
@@ -2143,8 +2143,8 @@ join(BTreeBase<K, V, Fanout, Comp, AllowDup, AllocTemplate> &&tree_left,
          &&tree_right) requires
     std::is_constructible_v<V, std::remove_cvref_t<T_>> {
   using Tree = BTreeBase<K, V, Fanout, Comp, AllowDup, AllocTemplate>;
-  using Node = Tree::node_type;
-  using Proj = Tree::Proj;
+  using Node = typename Tree::node_type;
+  using Proj = typename Tree::Proj;
   constexpr bool is_disk_ = Tree::is_disk_;
 
   V mid_value{std::forward<T_>(raw_value)};


### PR DESCRIPTION
The latest Xcode version available (14.3.1) ships AppleClang compiler that is based on the open-source upstream LLVM 14.0.3, which does not support the P0634R3 C++20 feature.

This commit workarounds that by adding 'typename' keyword where necessary.